### PR TITLE
[rpm] Flip the container image to a UBI 9 image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:39
+FROM registry.access.redhat.com/ubi9:9.6-1752625787
 
 RUN dnf -y install vim
 

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: ubi-9-appstream-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/os
+    - repoid: ubi-9-baseos-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os
+packages:
+  - name: vim
+    arches:
+      only: x86_64
+installWeakDeps: false

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1,62 +1,36 @@
+---
 lockfileVersion: 1
 lockfileVendor: redhat
 arches:
-  - arch: x86_64
-    packages:
-      - repoid: rpmfusion-free
-        url: https://download1.rpmfusion.org/free/fedora/releases/39/Everything/x86_64/os/Packages/l/libftl-0.9.14-12.fc39.x86_64.rpm
-        size: "41296"
-        checksum: sha256:6b0d8d3329150151fb8ea1eba7a4b464f112326777bee7a2e202753adc767281
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-data-9.0.1927-1.fc39.noarch.rpm
-        size: "23894"
-        checksum: sha256:35d7b9542e46eca30d951960effe9a8e738543a839f0dbb3cf723da0958c355b
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-minimal-9.0.1927-1.fc39.x86_64.rpm
-        size: "818364"
-        checksum: sha256:37a216f1af9f2eb961a9fa6674861146d11ca56fc9c576fa17a8cb7d806aa0af
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/g/gpm-libs-1.20.7-44.fc39.x86_64.rpm
-        size: "20720"
-        checksum: sha256:f5c8f20f0f9468da8cdf140d7df30ed117a43b73eee816888e2624b0fcd048ca
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/l/libsodium-1.0.18-14.fc39.x86_64.rpm
-        size: "165965"
-        checksum: sha256:e38200a7b1012935dc83e8039c71c0fd2f84a4463ca086cb42f60f488cdad8e7
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-common-9.0.1927-1.fc39.x86_64.rpm
-        size: "7784784"
-        checksum: sha256:4cb8015a858439f519d5d2aa82fd853f3d1dd7f927a33d25d9598e54ee6201bc
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-enhanced-9.0.1927-1.fc39.x86_64.rpm
-        size: "1950948"
-        checksum: sha256:615d46a08fbbd0eca6a6e8d2d23a6b5847db11c886e0dc979ffebab66236532d
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-filesystem-9.0.1927-1.fc39.noarch.rpm
-        size: "18444"
-        checksum: sha256:f645ed8cda2fa07ba991320a684d9b71de75ff25220468b08fb36f6a5a231178
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/w/which-2.21-40.fc39.x86_64.rpm
-        size: "42835"
-        checksum: sha256:ec1d8a1c0d88883a03e96ba88a6278899bd559fb37833cb2383ffdd6a38c22ae
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/x/xxd-9.0.1927-1.fc39.x86_64.rpm
-        size: "37332"
-        checksum: sha256:e770b0a0e5e51225a76069d2210551a90f3140913f90f33759d002055179ecc7
-    source:
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/source/tree/Packages/v/vim-9.0.1927-1.fc39.src.rpm
-        size: "14382769"
-        checksum: sha256:dae76267f265093d0e1b178c05af197bc21b994a264c9c4e7701cce095b62f03
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/source/tree/Packages/g/gpm-1.20.7-44.fc39.src.rpm
-        size: "251337"
-        checksum: sha256:2eb2412dde91b1130433c90ad53b889cb1e0fb0df324e015f29e76d7235ac438
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/source/tree/Packages/l/libsodium-1.0.18-14.fc39.src.rpm
-        size: "1953916"
-        checksum: sha256:d20e5f6e358aa0c07260872ffb00d502f77778ae7496a836da0a65a6ce1cd709
-      - repoid: releases
-        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/source/tree/Packages/w/which-2.21-40.fc39.src.rpm
-        size: "182684"
-        checksum: sha256:791428d30c136a2ff8e781b9c32cbd3d506699f1369ae2a589c02fceb72d4533
+- arch: x86_64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gpm-libs-1.20.7-29.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 23036
+    checksum: sha256:fc3455407e79462bfd944eea5d11d19186ad741be5a83e7ac1720fc181e3cc90
+    name: gpm-libs
+    evr: 1.20.7-29.el9
+    sourcerpm: gpm-1.20.7-29.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/v/vim-common-8.2.2637-22.el9_6.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 7345546
+    checksum: sha256:2204d3adc043d761081a2d39c75004ec4880dfc29de755c58d5fa4e15c81d3c3
+    name: vim-common
+    evr: 2:8.2.2637-22.el9_6
+    sourcerpm: vim-8.2.2637-22.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/v/vim-enhanced-8.2.2637-22.el9_6.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 1833149
+    checksum: sha256:aed2e552a0721e5d260362bc4013691a4cd722664e6cb6c93d70ddaf1548fd57
+    name: vim-enhanced
+    evr: 2:8.2.2637-22.el9_6
+    sourcerpm: vim-8.2.2637-22.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 17723
+    checksum: sha256:744aceed764a5a4f5e4f12a70237ff74cb93c375aabffe4dc245e474628775c2
+    name: vim-filesystem
+    evr: 2:8.2.2637-22.el9_6
+    sourcerpm: vim-8.2.2637-22.el9_6.src.rpm
+  source: []
+  module_metadata: []


### PR DESCRIPTION
Older Fedora releases move package registries to an archive after having been EOL'd for some time which means the URLs change [1], [2]. Let's replace the old Fedora image with a UBI-9 where we should be access the packages using the same URL for a long time. Since the repo didn't list an rpms.in.yaml file, let's add one for easier lockfile regenerating in the future.

[1] https://dl.fedoraproject.org/pub/fedora/linux/releases/39/
[2] https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/39/