### PR TITLE
Add pip/legacy-cachito-hash integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,4 @@
-# Hermeto integration tests repository
+# Legacy Cachito hash test
 
-This repository hosts the integration tests for our project. Each branch represents a different test
-case. Please ignore README.md files in those branches at the moment. They might not be up to date.
-
-The branch names begin with a prefix indicating a package manager, followed by the
-test case name in the format: `<package-manager>/<test-case>`.
-
-To create a new test please create or request a new branch in GitHub UI first
-and then open a PR against this branch. Alternatively, you can push an empty
-branch first if you have push rights. Please avoid pushing non-empty branches
-since that would hinder the visibility of changes made to this repository in
-context of the main project repository.
+This test covers a scenario where the Cachito hash as a qualifier in the URL of a dependency. It is
+a legacy functionality from Cachito, but it is still supported by Hermeto. See `requirements.txt`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "foo"
+version = "0.1.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+https://github.com/encode/httpx/archive/refs/tags/0.28.0.zip#egg=httpx&cachito_hash=sha256:14903e7fd80ad0df4a30f387a10270249685e600ad9c20dda3c139db061516e4


### PR DESCRIPTION
This test should replace pip/mixed-hashes which contains legacy cachito hash qualifier with manually added standard sha256 hash to an URL dependency.

The functionality is still supported in our pip backend, so it is worth having a simple integration test. Once we remove it from Hermeto, this test can be removed as well.

There is only one dependency in `requirements.txt` without any Rust extensions, which happened to be in pip/mixed-hashes test.