### PR TITLE
migrate npm without-deps fixture from cachito-testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,4 @@
-# Hermeto integration tests repository
+# npm package without dependencies
 
-This repository hosts the integration tests for our project. Each branch represents a different test
-case. Please ignore README.md files in those branches at the moment. They might not be up to date.
-
-The branch names begin with a prefix indicating a package manager, followed by the
-test case name in the format: `<package-manager>/<test-case>`.
-
-To create a new test please create or request a new branch in GitHub UI first
-and then open a PR against this branch. Alternatively, you can push an empty
-branch first if you have push rights. Please avoid pushing non-empty branches
-since that would hinder the visibility of changes made to this repository in
-context of the main project repository.
+This test case provides a minimal npm package with no dependencies,
+used as a Hermeto integration test fixture for tarball-based installs.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+console.log("Hello World!");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "npm-without-deps",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "npm-without-deps",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Move the [cachito-npm-without-deps](https://github.com/cachito-testing/cachito-npm-without-deps) test package into the Hermeto org without changing its behavior, so it can be used as an internal npm tarball-based integration fixture.
This fixture is used in multitude of integration tests which i plan on updating after this merge.