### PR TITLE
replace cachito npm-without-deps with hermeto copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cachito-npm-with-multiple-dep-versions
+# npm-with-multiple-dep-versions
 
 This test package includes multiple versions of the is-positive dependency
-in order to test cachito npm non-registry dependency replacement.
+in order to test npm non-registry dependency replacement.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cachito-npm-with-multiple-dep-versions",
+  "name": "npm-with-multiple-dep-versions",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cachito-npm-with-multiple-dep-versions",
+      "name": "npm-with-multiple-dep-versions",
       "version": "1.0.0",
       "license": "ISC",
       "workspaces": [
@@ -15,7 +15,7 @@
         "is-positive": "github:kevva/is-positive#1187a61f2e18cf7c11c23d61a1bd52b9fa6a5fdf"
       },
       "devDependencies": {
-        "cachito-npm-without-deps": "git+https://github.com/cachito-testing/cachito-npm-without-deps.git"
+        "npm-without-deps": "git+https://github.com/hermetoproject/integration-tests.git#npm/without-deps"
       }
     },
     "foo": {
@@ -35,11 +35,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/cachito-npm-without-deps": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/cachito-testing/cachito-npm-without-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6",
-      "dev": true
-    },
     "node_modules/foo": {
       "resolved": "foo",
       "link": true
@@ -52,6 +47,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/npm-without-deps": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/hermetoproject/integration-tests.git#b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cachito-npm-with-multiple-dep-versions",
+  "name": "npm-with-multiple-dep-versions",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -12,7 +12,7 @@
     "is-positive": "github:kevva/is-positive#1187a61f2e18cf7c11c23d61a1bd52b9fa6a5fdf"
   },
   "devDependencies": {
-    "cachito-npm-without-deps": "git+https://github.com/cachito-testing/cachito-npm-without-deps.git"
+    "npm-without-deps": "git+https://github.com/hermetoproject/integration-tests.git#npm/without-deps"
   },
   "workspaces": [
     "foo"


### PR DESCRIPTION
merge all npm-without-deps PR's after approval at the same time
AFTER WHICH WILL REQUIRE HERMETO-SIDE TEST UPDATE

tested in hermeto with
```
HERMETO_TEST_INTEGRATION_TESTS_REPO=https://github.com/derasdf/integration-tests.git \
HERMETO_TEST_GENERATE_DATA=1 \
python -m pytest \
    'tests/integration/test_npm.py::test_e2e_npm[npm_multiple_dep_versions]' \
    -v