### PR TITLE
replace cachito npm-without-deps with hermeto copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# npm-cachi2-smoketest
+# npm-hermeto-smoketest
 Prepare acceptance testing for npm offline implementation

--- a/bar/package.json
+++ b/bar/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests#readme",
   "dependencies": {
     "uuid": "^9.0.0"
   }

--- a/baz/package.json
+++ b/baz/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests#readme",
   "dependencies": {
     "dateformat": "^5.0.3",
     "bitbucket-cachi2-npm-without-deps": "https://bitbucket.org/cachi-testing/cachi2-without-deps.git"

--- a/eggs-packages/eggs/package.json
+++ b/eggs-packages/eggs/package.json
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests#readme",
   "dependencies": {
     "classnames": "^2.3.2"
   }

--- a/foo/package.json
+++ b/foo/package.json
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests#readme",
   "dependencies": {
     "abbrev": "^2.0.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,11 @@
       "dependencies": {
         "@types/react-dom": "^18.0.1",
         "bitbucket-cachi2-npm-without-deps-second": "https://bitbucket.org/cachi-testing/cachi2-without-deps-second.git",
-        "cachito-npm-without-deps": "https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
         "debug": "",
         "express": "^4.18.2",
         "fecha": "file:fecha-4.2.3.tgz",
         "is-positive": "github:kevva/is-positive",
+        "npm-without-deps": "https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
         "sax": "0.1.1"
       }
     },
@@ -151,11 +151,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/cachito-npm-without-deps": {
-      "version": "1.0.0",
-      "resolved": "https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
-      "integrity": "sha512-Q+cfkK1fnrNJqxiig/iVSZTe83OWLdxhuGa96k1IJJ5nkTxrhNyh6MUZ6YHKH8xitDgpIQSojuntctt2pB7+3g=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -521,6 +516,11 @@
       "resolved": "baz",
       "link": true
     },
+    "node_modules/npm-without-deps": {
+      "version": "1.0.0",
+      "resolved": "https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
+      "integrity": "sha512-jBq/ZIQaRF6zhMWqXCbDpR1UyHbbYnd6O1/D5N69KeK/aOS3T+b7wyKh0MTPAv0maKXfc669QRjFSTHRjKCGoQ=="
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -851,10 +851,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
-    "cachito-npm-without-deps": {
-      "version": "https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
-      "integrity": "sha512-Q+cfkK1fnrNJqxiig/iVSZTe83OWLdxhuGa96k1IJJ5nkTxrhNyh6MUZ6YHKH8xitDgpIQSojuntctt2pB7+3g=="
-    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1134,6 +1130,10 @@
         "bitbucket-cachi2-npm-without-deps": "https://bitbucket.org/cachi-testing/cachi2-without-deps.git",
         "dateformat": "^5.0.3"
       }
+    },
+    "npm-without-deps": {
+      "version": "https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
+      "integrity": "sha512-jBq/ZIQaRF6zhMWqXCbDpR1UyHbbYnd6O1/D5N69KeK/aOS3T+b7wyKh0MTPAv0maKXfc669QRjFSTHRjKCGoQ=="
     },
     "object-inspect": {
       "version": "1.12.3",

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests#readme",
   "workspaces": [
     "foo",
     "./bar",
@@ -30,7 +30,7 @@
     "debug": "",
     "sax": "0.1.1",
     "is-positive": "github:kevva/is-positive",
-    "cachito-npm-without-deps": "https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
+    "npm-without-deps": "https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
     "bitbucket-cachi2-npm-without-deps-second": "https://bitbucket.org/cachi-testing/cachi2-without-deps-second.git",
     "fecha": "file:fecha-4.2.3.tgz"
   }

--- a/spam-packages/spam/package.json
+++ b/spam-packages/spam/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests#readme",
   "dependencies": {
     "colors": "^1.4.0"
   }


### PR DESCRIPTION
merge all npm-without-deps PR's after approval at the same time
AFTER WHICH WILL REQUIRE HERMETO-SIDE TEST UPDATE

tested in hermeto with
```
HERMETO_TEST_INTEGRATION_TESTS_REPO=https://github.com/derasdf/integration-tests.git \
HERMETO_TEST_GENERATE_DATA=1 \
python -m pytest \
    'tests/integration/test_npm.py::test_e2e_npm[npm_smoketest_lockfile2]' \
    -v
