### PR TITLE
replace cachito npm-without-deps with hermeto copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yarnberry Unsupported Protocols Integration Test
 
-This branch uses dependencies with the Git, GitHub and Exec protocols, which Cachi2
+This branch uses dependencies with the Git, GitHub and Exec protocols, which Hermeto
 does not support. Executing `yarn install` in the presence of such dependencies would
 lead to arbitrary code execution.
 
@@ -11,5 +11,5 @@ git grep 'commit='
 git grep 'exec:'
 ```
 
-When processing this branch, Cachi2 should log the locator for each unsupported
+When processing this branch, Hermeto should log the locator for each unsupported
 dependency and raise an UnsupportedFeature error.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ansi-regex-link": "link:external-packages/ansi-regex",
     "c2-wo-deps": "https://bitbucket.org/cachi-testing/cachi2-without-deps.git",
     "c2-wo-deps-2": "https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
-    "ccto-wo-deps": "git@github.com:cachito-testing/cachito-npm-without-deps.git",
+    "ccto-wo-deps": "git@github.com:hermetoproject/integration-tests.git",
     "date-in-spanish": "npm:fecha@latest",
     "holy-hand-grenade": "exec:./generate-holy-hand-grenade.js",
     "is-positive": "github:kevva/is-positive",
@@ -31,7 +31,7 @@
     "yargs": "^17.7.2"
   },
   "resolutions": {
-    "ccto-wo-deps": "patch:ccto-wo-deps@git@github.com%3Acachito-testing/cachito-npm-without-deps.git%23commit=2f0ce1d7b1f8b35572d919428b965285a69583f6#./.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch"
+    "ccto-wo-deps": "patch:ccto-wo-deps@git@github.com%3Ahermetoproject/integration-tests.git%23commit=b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81#./.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch"
   },
   "workspaces": [
     "packages/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,7 +187,7 @@ __metadata:
     ansi-regex-link: "link:external-packages/ansi-regex"
     c2-wo-deps: "https://bitbucket.org/cachi-testing/cachi2-without-deps.git"
     c2-wo-deps-2: "https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz"
-    ccto-wo-deps: "git@github.com:cachito-testing/cachito-npm-without-deps.git"
+    ccto-wo-deps: "git@github.com:hermetoproject/integration-tests.git"
     chalk: ^5.3.0
     date-in-spanish: "npm:fecha@latest"
     emoji-regex: "https://github.com/mathiasbynens/emoji-regex.git"
@@ -270,16 +270,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ccto-wo-deps@git@github.com:cachito-testing/cachito-npm-without-deps.git#commit=2f0ce1d7b1f8b35572d919428b965285a69583f6":
+"ccto-wo-deps@git@github.com:hermetoproject/integration-tests.git#commit=b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81":
   version: 1.0.0
-  resolution: "ccto-wo-deps@git@github.com:cachito-testing/cachito-npm-without-deps.git#commit=2f0ce1d7b1f8b35572d919428b965285a69583f6"
+  resolution: "ccto-wo-deps@git@github.com:hermetoproject/integration-tests.git#commit=b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81"
   checksum: 3ed9ea417c75a1999925159e67cf04bf2d522967692a55321559ef2b353fa690167b7bc40e989e4ee35e36d095f007f2d0c53faeb55f14d07ec3ece34faba206
   languageName: node
   linkType: hard
 
-"ccto-wo-deps@patch:ccto-wo-deps@git@github.com%3Acachito-testing/cachito-npm-without-deps.git%23commit=2f0ce1d7b1f8b35572d919428b965285a69583f6#./.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch::locator=berryscary%40workspace%3A.":
+"ccto-wo-deps@patch:ccto-wo-deps@git@github.com%3Ahermetoproject/integration-tests.git%23commit=b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81#./.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch::locator=berryscary%40workspace%3A.":
   version: 1.0.0
-  resolution: "ccto-wo-deps@patch:ccto-wo-deps@git@github.com%3Acachito-testing/cachito-npm-without-deps.git%23commit=2f0ce1d7b1f8b35572d919428b965285a69583f6#./.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch::version=1.0.0&hash=51a91f&locator=berryscary%40workspace%3A."
+  resolution: "ccto-wo-deps@patch:ccto-wo-deps@git@github.com%3Ahermetoproject/integration-tests.git%23commit=b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81#./.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch::version=1.0.0&hash=51a91f&locator=berryscary%40workspace%3A."
   checksum: 98355f046f66b70b4ae4aec87fb20c83eb635a7138b5bb25dcbfa567ae4fcc4240ff1178de2f985776ab6cea1f55af8e085d798f5077b8a8b5bb5cb5278293d4
   languageName: node
   linkType: hard


### PR DESCRIPTION
merge all npm-without-deps PR's after approval at the same time
AFTER WHICH WILL REQUIRE HERMETO-SIDE TEST UPDATE

tested in hermeto with
```
HERMETO_TEST_INTEGRATION_TESTS_REPO=https://github.com/derasdf/integration-tests.git \
HERMETO_GENERATE_TEST_DATA=true \
python -m pytest \
    'tests/integration/test_yarn.py::test_yarn_packages[yarn_disallowed_protocols]' \
    -v
