### PR TITLE
replace cachito npm-workspaces with hermeto copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# npm-yarn-registry-lockfile3
+
+This repo is for testing npm support in [Hermeto](https://github.com/hermetoproject/hermeto).
+
+The main package is named `npm-yarn-registry-test`. There are several workspaces defined, each with a unique dependency.
+
+An example of the commands needed to create the main package and one of the workspaces is:
+
+```
+npm init -y
+npm init -w foo
+npm install abbrev -w foo
+npm install
+```
+
+Note: The pre-existing dependencies in `package-lock.json` are resolved from `registry.yarnpkg.com`, while dependencies added locally (e.g. `abbrev`) resolve from `registry.npmjs.org`, resulting in a mixed-registry lockfile v3.

--- a/bar/package.json
+++ b/bar/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git#npm/yarn-registry-lockfile3"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests/tree/npm/yarn-registry-lockfile3#readme",
   "dependencies": {
     "uuid": "^9.0.0"
   }

--- a/baz/package.json
+++ b/baz/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git#npm/yarn-registry-lockfile3"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests/tree/npm/yarn-registry-lockfile3#readme",
   "dependencies": {
     "dateformat": "^5.0.3",
     "bitbucket-cachi2-npm-without-deps": "git@bitbucket.org:cachi-testing/cachi2-without-deps.git"

--- a/eggs-packages/eggs/package.json
+++ b/eggs-packages/eggs/package.json
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git#npm/yarn-registry-lockfile3"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests/tree/npm/yarn-registry-lockfile3#readme",
   "dependencies": {
     "classnames": "^2.3.2"
   }

--- a/foo/package.json
+++ b/foo/package.json
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git#npm/yarn-registry-lockfile3"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests/tree/npm/yarn-registry-lockfile3#readme",
   "dependencies": {
     "abbrev": "^2.0.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "npm-cachi2-yarn-registry-test",
+  "name": "npm-yarn-registry-test",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "npm-cachi2-yarn-registry-test",
+      "name": "npm-yarn-registry-test",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "npm-cachi2-yarn-registry-test",
+  "name": "npm-yarn-registry-test",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -7,15 +7,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git#npm/yarn-registry-lockfile3"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests/tree/npm/yarn-registry-lockfile3#readme",
   "description": "",
   "private": true,
   "dependencies": {

--- a/spam-packages/spam/package.json
+++ b/spam-packages/spam/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cachito-testing/cachito-npm-workspaces.git"
+    "url": "git+https://github.com/hermetoproject/integration-tests.git#npm/yarn-registry-lockfile3"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cachito-testing/cachito-npm-workspaces/issues"
+    "url": "https://github.com/hermetoproject/integration-tests/issues"
   },
-  "homepage": "https://github.com/cachito-testing/cachito-npm-workspaces#readme",
+  "homepage": "https://github.com/hermetoproject/integration-tests/tree/npm/yarn-registry-lockfile3#readme",
   "dependencies": {
     "colors": "^1.4.0"
   }


### PR DESCRIPTION
**_MERGING THIS WILL BREAK HERMETO CI_**
i'll merge it myself when time is right

original repo https://github.com/cachito-testing/cachito-npm-workspaces/tree/master

tested in hermeto with
```
HERMETO_TEST_INTEGRATION_TESTS_REPO=https://github.com/derasdf/integration-tests.git \
HERMETO_TEST_GENERATE_DATA=1 \
python -m pytest \
    'tests/integration/test_npm.py::test_npm_packages[npm_yarn_registry_lockfile3]' \
    -v
