### PR TITLE
replace cachito go-generate with hermeto copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
 # go-generate-imported
 
-Repo for testing how Cachito handles packages, specifically for repos which use `go generate`. See [go generate](https://go.dev/blog/generate). <br/>
+Repo for testing how Hermeto handles packages, specifically for repos which use `go generate`. See [go generate](https://go.dev/blog/generate). <br/>
 Such repos can be identified with a `//go:generate ...` comment in the `main.go` file. <br/>
-There are **4** of these repos with distinct characteristics: <br/>
-1. [Directory foobar is empty and `main.go` does not import package `foobar`](https://github.com/cachito-testing/go-generate) <br/>
-2. [Directory foobar contains `foobar.go` and `main.go` does not import package `foobar`](https://github.com/cachito-testing/go-generate-generated) <br/>
-3. **Directory foobar is empty and `main.go` imports package `foobar`** <br/>
-4. [Directory foobar contains `foobar.go` and `main.go` imports package `foobar`](https://github.com/cachito-testing/go-generate-imported-generated) <br/>
 
-This is **case 3**. In this case, Cachito request recognizes "main" as a package and "foobar" as a dependency (1pkg, 1dep) <br/>
+This is the case where directory foobar is empty and `main.go` imports package `foobar`. Hermeto request recognizes "main" as a package and "foobar" as a dependency (1pkg, 1dep) <br/>
 ├── foobar <br/>
 │   └── \<empty> <br/>
 └── main.go ("package main") *IMPORTS FOOBAR <br/>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/cachito-testing/go-generate-imported
+module github.com/hermetoproject/integration-tests
 
 go 1.17

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/cachito-testing/go-generate-imported/foobar"
+import "github.com/hermetoproject/integration-tests/foobar"
 
 //go:generate go run internal/generate/generatefoobar.go
 


### PR DESCRIPTION
merge all similar PR's after approval at the same time
**_AFTER WHICH WILL REQUIRE HERMETO-SIDE TEST UPDATE_**

tested in hermeto with
```
HERMETO_TEST_INTEGRATION_TESTS_REPO=https://github.com/derasdf/integration-tests.git \
HERMETO_TEST_GENERATE_DATA=1 \
python -m pytest \
    'tests/integration/test_gomod.py::test_gomod_packages[gomod_generate_imported]' \
    -v
```