### PR TITLE
build(deps): update requirements.txt for new pypi-proxy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
---index-url=http://127.0.0.1:8080/simple/
+--index-url=https://127.0.0.1:8443/repository/pypi-proxy/simple
 requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6


### PR DESCRIPTION
The integration tests now use TLS and Nexus Repository Server.