### PR TITLE
Update the RPM lockfile

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -3,12 +3,12 @@ lockfileVendor: redhat
 arches:
 - arch: x86_64
   packages:
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-28.el9.noarch.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-36.el9.noarch.rpm
     repoid: baseos
     size: 9771
-    checksum: sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a584
+    checksum: sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8
     name: centos-stream-repos
-    evr: 9.0-28.el9
-    sourcerpm: centos-stream-release-9.0-28.el9.src.rpm
+    evr: 9.0-36.el9
+    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
The centos-stream-repos-9 release 28 is no longer available, bump to a newer version.

https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-28.el9.noarch.rpm