### PR TITLE
Update the RPM lockfile

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -4,12 +4,12 @@ lockfileVendor: redhat
 arches:
 - arch: x86_64
   packages:
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-28.el9.noarch.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-36.el9.noarch.rpm
     repoid: baseos
-    size: 9770
+    size: 8917
     checksum: sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a585
     name: centos-stream-repos
-    evr: 9.0-28.el9
-    sourcerpm: centos-stream-release-9.0-28.el9.src.rpm
+    evr: 9.0-36.el9
+    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
The centos-stream-repos-9 release 28 is no longer available, bump to a newer version.

https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-28.el9.noarch.rpm