### PR TITLE
Update the RPM lockfile

### DIFF
--- a/another-project/rpms.lock.yaml
+++ b/another-project/rpms.lock.yaml
@@ -11,13 +11,13 @@ arches:
       name: alternatives
       evr: 1.24-2.el9
       sourcerpm: chkconfig-1.24-2.el9.src.rpm
-    - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-28.el9.noarch.rpm
+    - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-36.el9.noarch.rpm
       repoid: baseos
-      size: 9770
-      checksum: sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a584
+      size: 8917
+      checksum: sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8
       name: centos-stream-repos
-      evr: 9.0-28.el9
-      sourcerpm: centos-stream-release-9.0-28.el9.src.rpm
+      evr: 9.0-36.el9
+      sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
     - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libcom_err-1.46.5-8.el9.x86_64.rpm
       repoid: baseos
       size: 26931

--- a/this-project/rpms.lock.yaml
+++ b/this-project/rpms.lock.yaml
@@ -11,12 +11,12 @@ arches:
       name: alternatives
       evr: 1.24-2.el9
       sourcerpm: chkconfig-1.24-2.el9.src.rpm
-    - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-28.el9.noarch.rpm
+    - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-36.el9.noarch.rpm
       repoid: baseos
-      size: 9770
+      size: 8917
       name: centos-stream-repos
-      evr: 9.0-28.el9
-      sourcerpm: centos-stream-release-9.0-28.el9.src.rpm
+      evr: 9.0-36.el9
+      sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
     - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libcom_err-1.46.5-4.el9.x86_64.rpm
       repoid: baseos
       size: 26841


### PR DESCRIPTION
The centos-stream-repos-9 release 28 is no longer available, bump to a newer version.

https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-28.el9.noarch.rpm