### PR TITLE
remove dead bitbucket cachi-testing deps

### DIFF
--- a/baz/package.json
+++ b/baz/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/hermetoproject/integration-tests#readme",
   "dependencies": {
-    "dateformat": "^5.0.3",
-    "bitbucket-cachi2-npm-without-deps": "git@bitbucket.org:cachi-testing/cachi2-without-deps.git"
+    "dateformat": "^5.0.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       ],
       "dependencies": {
         "@types/react-dom": "^18.0.1",
-        "bitbucket-cachi2-npm-without-deps-second": "git+https://bitbucket.org/cachi-testing/cachi2-without-deps-second.git",
         "debug": "",
         "express": "^4.18.2",
         "fecha": "file:fecha-4.2.3.tgz",
@@ -38,7 +37,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bitbucket-cachi2-npm-without-deps": "git@bitbucket.org:cachi-testing/cachi2-without-deps.git",
         "dateformat": "^5.0.3"
       }
     },
@@ -112,14 +110,6 @@
     "node_modules/bar": {
       "resolved": "bar",
       "link": true
-    },
-    "node_modules/bitbucket-cachi2-npm-without-deps": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git#9e164b97043a2d91bbeb992f6cc68a3d1015086a"
-    },
-    "node_modules/bitbucket-cachi2-npm-without-deps-second": {
-      "version": "2.0.0",
-      "resolved": "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982"
     },
     "node_modules/body-parser": {
       "version": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "sax": "0.1.1",
     "is-positive": "github:kevva/is-positive",
     "npm-without-deps": "https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
-    "bitbucket-cachi2-npm-without-deps-second": "git+https://bitbucket.org/cachi-testing/cachi2-without-deps-second.git",
     "fecha": "file:fecha-4.2.3.tgz"
   }
 }


### PR DESCRIPTION
remove dead bitbucket cachi-testing deps

tested in hermeto with
```
  HERMETO_TEST_INTEGRATION_TESTS_REPO=https://github.com/derasdf/integration-tests.git \
  HERMETO_TEST_GENERATE_DATA=1 \
  python -m pytest \
      'tests/integration/test_npm.py::test_e2e_npm[npm_smoketest_lockfile3]' \
      -v
