### PR TITLE
remove dead bitbucket cachi-testing deps

### DIFF
--- a/second_pkg/package-lock.json
+++ b/second_pkg/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bitbucket-cachi2-npm-without-deps-second": "https://bitbucket.org/cachi-testing/cachi2-without-deps-second.git",
         "debug": "",
         "express": "^4.18.2",
         "sax": "0.1.1"
@@ -31,10 +30,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-    },
-    "node_modules/bitbucket-cachi2-npm-without-deps-second": {
-      "version": "2.0.0",
-      "resolved": "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982"
     },
     "node_modules/body-parser": {
       "version": "1.20.1",

--- a/second_pkg/package.json
+++ b/second_pkg/package.json
@@ -17,7 +17,6 @@
   "homepage": "https://github.com/hermetoproject/integration-tests#readme",
   "description": "",
   "dependencies": {
-    "bitbucket-cachi2-npm-without-deps-second": "https://bitbucket.org/cachi-testing/cachi2-without-deps-second.git",
     "debug": "",
     "express": "^4.18.2",
     "sax": "0.1.1"


### PR DESCRIPTION
tested with
```
HERMETO_TEST_INTEGRATION_TESTS_REPO=https://github.com/derasdf/integration-tests.git \
HERMETO_TEST_GENERATE_DATA=1 \
python -m pytest \
'tests/integration/test_npm.py::test_e2e_npm[npm_multiple_packages]' \
-v

