### PR TITLE
remove dead bitbucket cachi-testing deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "ansi-regex-link": "link:external-packages/ansi-regex",
-    "c2-wo-deps-2": "https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
     "ccto-wo-deps": "https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
     "date-in-spanish": "npm:fecha@latest",
     "holy-hand-grenade": "link:book-of-armaments",

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,7 +185,6 @@ __metadata:
     "@types/node": ^20.4.5
     "@types/yargs": ^17
     ansi-regex-link: "link:external-packages/ansi-regex"
-    c2-wo-deps-2: "https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz"
     ccto-wo-deps: "https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz"
     chalk: ^5.3.0
     date-in-spanish: "npm:fecha@latest"
@@ -232,13 +231,6 @@ __metadata:
   dependencies:
     balanced-match: ^1.0.0
   checksum: a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
-  languageName: node
-  linkType: hard
-
-"c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz":
-  version: 2.0.0
-  resolution: "c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz"
-  checksum: b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
tested with
```
HERMETO_TEST_INTEGRATION_TESTS_REPO=https://github.com/derasdf/integration-tests.git
HERMETO_TEST_GENERATE_DATA=1
python -m pytest
'tests/integration/test_yarn.py::test_e2e_yarn[yarn_e2e]'
-v